### PR TITLE
BUGFIX: Other packages need phpcs in v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/Codappix/CGL-PHP/"
     },
     "require": {
-        "squizlabs/php_codesniffer": "^3.2",
+        "squizlabs/php_codesniffer": "^2.9|^3.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffe05e44f3056762fe92d9f920ddb2a0",
+    "content-hash": "96627dc64c0a094e3d9809030bbe0043",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
TYPO3SniffPool needs v2 of phpcs.